### PR TITLE
feat(gitea): add option `gitea-release-exists-do` at handle existing releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Please read [Contributor Guide](.github/CONTRIBUTING_DOC/CONTRIBUTING.md) for mo
 - [x] out publish info json file default `dist/go-mod-upload.json`
     - use `settings.gitea-publish-golang-update-result-root-path` to change out root path, default `dist`
     - use `settings.gitea-publish-golang-update-result-file-name` to change out file name, default `go-mod-upload.json`
+- [x] args `gitea-release-exists-do`
+    - package release exists do, support `[fail skip overwrite]` ,{version 1.2+} (default: "fail")
 - [ ] more perfect test case coverage
 - [ ] more perfect benchmark case
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -34,7 +34,8 @@ plugin as https://woodpecker-ci.org/ for https://docs.gitea.com/usage/packages/g
 | `gitea-publish-golang-base-url`                | **no**   |                      | gitea base url, default by `CI_FORGE_URL`                                                                   |
 | `gitea-publish-golang-insecure`                | **no**   | *false*              | gitea insecure enable                                                                                       |
 | `gitea-publish-golang-dry-run`                 | **no**   | *false*              | dry run mode                                                                                                |
-| `gitea-publish-golang-path-go`                 | **no**   |                      | publish go package is dir to find go.mod, will append project root path, default is this project root path  |
+| `gitea-release-exists-do`                      | **no**   | *fail*               | package release exists do, support `[fail skip overwrite]` ,{version 1.2+} (default: "fail")                |
+| `gitea-publish-golang-path-go`                 | **no**   | ""                   | publish go package is dir to find go.mod, will append project root path, default is this project root path  |
 | `gitea-publish-golang-remove-paths`            | **no**   | `["dist"]`           | publish go package remove paths, this path under `gitea-publish-golang-path-go`, default will remove `dist` |
 | `gitea-publish-golang-update-result-root-path` | **no**   | *dist*               | out result root path append CI Workspace, default `dist`                                                    |
 | `gitea-publish-golang-update-result-file-name` | **no**   | *go-mod-upload.json* | out file name, default `go-mod-upload.json`                                                                 |
@@ -68,6 +69,7 @@ steps:
       # gitea-publish-golang-dry-run: true # dry run mode
       gitea-publish-golang-api-key: # gitea api key, Required
         from_secret: gitea_api_key_release
+      gitea-release-exists-do: "fail" # support [fail skip overwrite] (default: "fail") {version 1.2+}
       gitea-publish-golang-path-go: "" # publish go package is dir to find go.mod, will append project root path, default is this project root path
       gitea-publish-golang-remove-paths: # publish go package remove paths, this path under `gitea-publish-golang-path-go`, default will remove `dist`
         - "dist"
@@ -103,6 +105,7 @@ steps:
       # gitea-publish-golang-dry-run: true # dry run mode
       gitea-publish-golang-api-key: # gitea api key, Required
         from_secret: gitea_api_key_release
+      gitea-release-exists-do: "fail" # support [fail skip overwrite] (default: "fail") {version 1.2+}
       gitea-publish-golang-path-go: "" # publish go package is dir to find go.mod, will append project root path, default is this project root path
       gitea-publish-golang-remove-paths: # publish go package remove paths, this path under `gitea-publish-golang-path-go`, default will remove `dist`
         - "dist"
@@ -127,6 +130,7 @@ steps:
         from_secret: gitea_api_key_release
       gitea-publish-golang-base-url: "https://gitea.example.com" # default by CI_FORGE_URL auto to find
       gitea-publish-golang-insecure: true #  gitea insecure enable
+      gitea-release-exists-do: "fail" # support [fail skip overwrite] (default: "fail") {version 1.2+}
       gitea-publish-golang-path-go: "sub-go" # publish go package is dir to find go.mod, will append project root path, default is this project root path
       gitea-publish-golang-remove-paths: # publish go package remove paths, this path under `gitea-publish-golang-path-go`, default will remove `dist`
         - "dist"
@@ -141,6 +145,8 @@ steps:
 
 ## Known limitations
 
-1. go mod zip file generate by `zip.CreateFromDir`, this method will check as [https://semver.org/](https://semver.org/), so this kit use `CI_COMMIT_TAG` to generate version
+1. go mod zip file generate by `zip.CreateFromDir`, this method will check
+   as [https://semver.org/](https://semver.org/), so this kit use `CI_COMMIT_TAG` to generate version
 2. open `gitea-publish-golang-dry-run` mode can pass all check, but not publish to gitea
-3. but without event tag will use version mark as `latest`, this will not pass `zip.CreateFromDir`check, so will not publish to gitea
+3. but without event tag will use version mark as `latest`, this will not pass `zip.CreateFromDir`check, so will not
+   publish to gitea

--- a/gitea_publish_golang/flag.go
+++ b/gitea_publish_golang/flag.go
@@ -28,6 +28,9 @@ const (
 	CliNameGiteaPubGolangRemovePaths = "settings.gitea-publish-golang-remove-paths"
 	EnvGiteaPubGolangRemovePaths     = "PLUGIN_GITEA_PUBLISH_GOLANG_REMOVE_PATHS"
 
+	CliNameGiteaReleaseExistsDo = "settings.gitea-release-exists-do"
+	EnvGiteaReleaseExistsDo     = "PLUGIN_GITEA_RELEASE_EXISTS_DO"
+
 	CliNameGiteaPubGolangUpdateResultRootPath = "settings.gitea-publish-golang-update-result-root-path"
 	EnvGiteaPubGolangUpdateResultRootPath     = "PLUGIN_GITEA_PUBLISH_GOLANG_UPDATE_RESULT_ROOT_PATH"
 
@@ -70,6 +73,13 @@ func GlobalFlag() []cli.Flag {
 			Value:   cli.NewStringSlice("dist"),
 			EnvVars: []string{EnvGiteaPubGolangRemovePaths},
 		},
+		&cli.StringFlag{
+			Name:    CliNameGiteaReleaseExistsDo,
+			Usage:   fmt.Sprintf("package release exists do, support %v ,{version 1.2+}", giteaReleaseExistDoSupport),
+			Value:   GiteaReleaseExistsDoFail,
+			EnvVars: []string{EnvGiteaReleaseExistsDo},
+		},
+
 		&cli.StringFlag{
 			Name:    CliNameGiteaPubGolangUpdateResultRootPath,
 			Usage:   "out result root path append CI Workspace, default `dist`",
@@ -126,6 +136,8 @@ func BindCliFlags(c *cli.Context,
 
 		PublishPackageGoPath: c.String(CliNameGiteaPubGolangPathGo),
 		PublishRemovePaths:   c.StringSlice(CliNameGiteaPubGolangRemovePaths),
+
+		GiteaReleaseExistDo: c.String(CliNameGiteaReleaseExistsDo),
 
 		ResultUploadRootPath: c.String(CliNameGiteaPubGolangUpdateResultRootPath),
 		ResultUploadFileName: c.String(CliNameGiteaPubGolangUpdateResultFileName),

--- a/gitea_publish_golang/gitea_api_define.go
+++ b/gitea_publish_golang/gitea_api_define.go
@@ -1,8 +1,15 @@
 package gitea_publish_golang
 
+import "code.gitea.io/sdk/gitea"
+
 type GiteaPackageInfo struct {
 	Id      uint64 `json:"id"`
 	Type    string `json:"type"`
 	Name    string `json:"name"`
 	Version string `json:"version"`
+
+	HtmlUrl    string           `json:"html_url"`
+	Creator    gitea.User       `json:"creator"`
+	Owner      gitea.User       `json:"owner"`
+	Repository gitea.Repository `json:"repository"`
 }

--- a/gitea_publish_golang/gitea_publish_golang_client.go
+++ b/gitea_publish_golang/gitea_publish_golang_client.go
@@ -34,6 +34,8 @@ type GiteaPublishGolangClient interface {
 
 	RemotePackageGoFetch(version string) (*GiteaPackageInfo, error)
 
+	DeletePackageGoFetch(version string) error
+
 	CreateGoModZip(version string, zipRootPath string, goModRootPath string, removePath []string) error
 
 	PackageGoUpload() (*PublishPackageGoInfo, error)

--- a/gitea_publish_golang/impl.go
+++ b/gitea_publish_golang/impl.go
@@ -86,6 +86,11 @@ func (p *GiteaPublishGolang) checkArgs() error {
 		return errCheck
 	}
 
+	errCheckGiteaReleaseSupport := argCheckInArr(CliNameGiteaReleaseExistsDo, p.Settings.GiteaReleaseExistDo, giteaReleaseExistDoSupport)
+	if errCheckGiteaReleaseSupport != nil {
+		return errCheckGiteaReleaseSupport
+	}
+
 	if p.Settings.GiteaBaseUrl == "" {
 		if p.woodpeckerInfo.CiForgeInfo.CiForgeType == "gitea" {
 			wd_log.Debugf("when CiForgeType [ gitea ] woodpeckerInfo.CiForgeInfo.CiForgeUrl [ %s ] as GiteaBaseUrl", p.woodpeckerInfo.CiForgeInfo.CiForgeUrl)

--- a/gitea_publish_golang/settings.go
+++ b/gitea_publish_golang/settings.go
@@ -2,6 +2,12 @@ package gitea_publish_golang
 
 import "github.com/woodpecker-kit/woodpecker-tools/wd_info"
 
+const (
+	GiteaReleaseExistsDoFail      = "fail"
+	GiteaReleaseExistsDoSkip      = "skip"
+	GiteaReleaseExistsDoOverwrite = "overwrite"
+)
+
 type (
 	// Settings gitea_publish_golang private config
 	Settings struct {
@@ -19,8 +25,13 @@ type (
 
 		PublishPackageGoPath string
 		// findOutGoModPath is the path to find go.mod file will change by check args
-		findOutGoModPath     string
-		PublishRemovePaths   []string
+		findOutGoModPath   string
+		PublishRemovePaths []string
+
+		// GiteaReleaseExistDo is the action to do when gitea release exist.
+		// support value is GiteaReleaseExistsDoFail, GiteaReleaseExistsDoSkip, GiteaReleaseExistsDoOverwrite
+		GiteaReleaseExistDo string
+
 		ResultUploadRootPath string
 		// resultRootFullPath is the root path of result with check args success
 		resultRootFullPath   string
@@ -36,6 +47,12 @@ type (
 )
 
 var (
+	giteaReleaseExistDoSupport = []string{
+		GiteaReleaseExistsDoFail,
+		GiteaReleaseExistsDoSkip,
+		GiteaReleaseExistsDoOverwrite,
+	}
+
 	// pluginBuildStateSupport
 	pluginBuildStateSupport = []string{
 		wd_info.BuildStatusCreated,

--- a/gitea_publish_golang_test/init_test.go
+++ b/gitea_publish_golang_test/init_test.go
@@ -21,6 +21,8 @@ const (
 	keyEnvCiKey  = "CI_KEY"
 	keyEnvCiKeys = "CI_KEYS"
 
+	envKeyProjectRootPath = "CI_PROJECT_ROOT_PATH"
+
 	mockVersion = "v1.0.0"
 	mockName    = "woodpecker-gitea-publisher-golang"
 )
@@ -49,6 +51,7 @@ var (
 	valEnvGiteaPubGolangInsecure    = false
 	valEnvGiteaPubGolangDryRun      = true
 	valEnvGiteaPubGolangPathGo      = ""
+	valGiteaReleaseExistDo          = ""
 	valEnvGiteaPubGolangRemovePaths = []string{
 		"dist",
 	}
@@ -56,12 +59,13 @@ var (
 
 	// CI Test Env
 
-	valCiRepoName   = ""
-	valCiRepoOwner  = ""
-	valCiSystemHost = ""
-	valCiSystemUrl  = ""
-	valCiForgeType  = "gitea"
-	valCiForgeUrl   = ""
+	varProjectRootPath = "" // change by env:CI_PROJECT_ROOT_PATH
+	valCiRepoName      = ""
+	valCiRepoOwner     = ""
+	valCiSystemHost    = ""
+	valCiSystemUrl     = ""
+	valCiForgeType     = "gitea"
+	valCiForgeUrl      = ""
 )
 
 func init() {
@@ -72,6 +76,7 @@ func init() {
 
 	testGoldenKit = unittest_file_kit.NewTestGoldenKit(testBaseFolderPath)
 
+	varProjectRootPath = env_kit.FetchOsEnvStr(envKeyProjectRootPath, "")
 	valCiRepoName = env_kit.FetchOsEnvStr(wd_flag.EnvKeyRepositoryCiName, "")
 	valCiRepoOwner = env_kit.FetchOsEnvStr(wd_flag.EnvKeyRepositoryCiOwner, "")
 	valCiSystemHost = env_kit.FetchOsEnvStr(wd_flag.EnvKeyCiSystemHost, "")
@@ -87,6 +92,7 @@ func init() {
 	valEnvGiteaPubGolangInsecure = env_kit.FetchOsEnvBool(gitea_publish_golang.EnvGiteaPubGolangInsecure, false)
 	valEnvGiteaPubGolangDryRun = env_kit.FetchOsEnvBool(gitea_publish_golang.EnvGiteaPubGolangDryRun, true)
 	valEnvGiteaPubGolangPathGo = env_kit.FetchOsEnvStr(gitea_publish_golang.EnvGiteaPubGolangPathGo, "")
+	valGiteaReleaseExistDo = env_kit.FetchOsEnvStr(gitea_publish_golang.EnvGiteaReleaseExistsDo, gitea_publish_golang.GiteaReleaseExistsDoFail)
 	removePathsEnv := env_kit.FetchOsEnvStringSlice(gitea_publish_golang.EnvGiteaPubGolangRemovePaths)
 	if len(removePathsEnv) > 0 {
 		valEnvGiteaPubGolangRemovePaths = removePathsEnv
@@ -154,6 +160,7 @@ func mockPluginSettings() gitea_publish_golang.Settings {
 	settings.GiteaInsecure = valEnvGiteaPubGolangInsecure
 	settings.PublishPackageGoPath = valEnvGiteaPubGolangPathGo
 	settings.PublishRemovePaths = valEnvGiteaPubGolangRemovePaths
+	settings.GiteaReleaseExistDo = valGiteaReleaseExistDo
 
 	return settings
 

--- a/gitea_publish_golang_test/plugin_test.go
+++ b/gitea_publish_golang_test/plugin_test.go
@@ -115,7 +115,7 @@ func TestPlugin(t *testing.T) {
 		),
 	)
 	tagPipelineSettings := mockPluginSettings()
-	tagPipelineSettings.GiteaReleaseExistDo = gitea_publish_golang.GiteaReleaseExistsDoOverwrite
+	tagPipelineSettings.GiteaReleaseExistDo = gitea_publish_golang.GiteaReleaseExistsDoSkip
 
 	// pullRequestPipeline
 	pullRequestPipelineWoodpeckerInfo := *wd_mock.NewWoodpeckerInfo(

--- a/gitea_publish_golang_test/plugin_test.go
+++ b/gitea_publish_golang_test/plugin_test.go
@@ -92,12 +92,14 @@ func TestPlugin(t *testing.T) {
 	t.Log("mock GiteaPublishGolang args")
 
 	testDataFolderFullPath := testGoldenKit.GetTestDataFolderFullPath()
-	projectRootPath := filepath.Dir(filepath.Dir(testDataFolderFullPath))
+	if varProjectRootPath == "" {
+		varProjectRootPath = filepath.Dir(filepath.Dir(testDataFolderFullPath))
+	}
 
 	// tagPipeline
 	tagPipelineWoodpeckerInfo := *wd_mock.NewWoodpeckerInfo(
-		wd_mock.FastWorkSpace(projectRootPath),
-		wd_mock.FastTag("v1.0.0", "new tag"),
+		wd_mock.FastWorkSpace(varProjectRootPath),
+		wd_mock.FastTag("v1.0.4", "new tag"),
 		wd_mock.WithCiForgeInfo(
 			wd_mock.WithCiForgeType(valCiForgeType),
 			wd_mock.WithCiForgeUrl(valCiForgeUrl),
@@ -113,10 +115,11 @@ func TestPlugin(t *testing.T) {
 		),
 	)
 	tagPipelineSettings := mockPluginSettings()
+	tagPipelineSettings.GiteaReleaseExistDo = gitea_publish_golang.GiteaReleaseExistsDoOverwrite
 
 	// pullRequestPipeline
 	pullRequestPipelineWoodpeckerInfo := *wd_mock.NewWoodpeckerInfo(
-		wd_mock.FastWorkSpace(projectRootPath),
+		wd_mock.FastWorkSpace(varProjectRootPath),
 		wd_mock.FastPullRequest("1", "new pr", "feature-support", "main", "main"),
 		wd_mock.WithCiForgeInfo(
 			wd_mock.WithCiForgeType(valCiForgeType),

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,11 @@ go 1.22.0
 toolchain go1.22.10
 
 require (
+	code.gitea.io/sdk/gitea v0.19.0
 	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/gookit/color v1.5.4
 	github.com/joho/godotenv v1.5.1
-	github.com/sinlov-go/gitea-client-wrapper v1.4.0
+	github.com/sinlov-go/gitea-client-wrapper v1.4.1
 	github.com/sinlov-go/go-common-lib v1.7.1
 	github.com/sinlov-go/unittest-kit v1.2.1
 	github.com/stretchr/testify v1.10.0
@@ -18,7 +19,6 @@ require (
 )
 
 require (
-	code.gitea.io/sdk/gitea v0.19.0 // indirect
 	github.com/chainguard-dev/git-urls v1.0.2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.5 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sinlov-go/gitea-client-wrapper v1.4.0 h1:6BXCkUnoPFfqhBrSxuJ1AgVtLVJEgUfW+HDD6Fresfw=
-github.com/sinlov-go/gitea-client-wrapper v1.4.0/go.mod h1:YdCgDtYoa+iCTpJB97iQBMu8uVm5/MUVTSd+XLtVi9U=
+github.com/sinlov-go/gitea-client-wrapper v1.4.1 h1:/6IUc3t9mF7FieovB2QTJ7nBVrgEPWXieQ0a4OcDRHA=
+github.com/sinlov-go/gitea-client-wrapper v1.4.1/go.mod h1:YdCgDtYoa+iCTpJB97iQBMu8uVm5/MUVTSd+XLtVi9U=
 github.com/sinlov-go/go-common-lib v1.7.1 h1:slVwwM/TiA7wzYYqRYMOHCOPmRLQn3NTU652fT2QWIE=
 github.com/sinlov-go/go-common-lib v1.7.1/go.mod h1:e+kY8eyLMnvayGezaWi3nU1VF5xsnMQ+DQUVdUC6Xbw=
 github.com/sinlov-go/unittest-kit v1.2.1 h1:iI8jKiJOuyrPXTZuQHRwUzuuiqE5EUdS3brziFTkb3Y=


### PR DESCRIPTION
fe #32

- Add `gitea-release-exists-do` setting to specify action when release exists
- Implement logic to fail, skip, or overwrite existing releases
- Update documentation and add unit tests for new functionality
