### PR TITLE
feat(action): update docker bake-action to v6 and improve build file checking

### DIFF
--- a/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
@@ -150,14 +150,22 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       -
+        name: check build files
+        run: |
+          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+
+      -
         name: Build
         id: bake
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
-            ${{ inputs.docker_bake_config_file_path }}
-            ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+            cwd://${{ inputs.docker_bake_config_file_path }}
+            cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}
           provenance: false

--- a/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
@@ -149,14 +149,22 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       -
+        name: check build files
+        run: |
+          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+
+      -
         name: Build
         id: bake
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
-            ${{ inputs.docker_bake_config_file_path }}
-            ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+            cwd://${{ inputs.docker_bake_config_file_path }}
+            cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}
           provenance: false

--- a/gitea_publish_golang/impl.go
+++ b/gitea_publish_golang/impl.go
@@ -81,11 +81,6 @@ func (p *GiteaPublishGolang) loadStepsTransfer() error {
 
 func (p *GiteaPublishGolang) checkArgs() error {
 
-	//errCheck := argCheckInArr("build status", p.wdShortInfo.Build.Status, pluginBuildStateSupport)
-	//if errCheck != nil {
-	//	return errCheck
-	//}
-
 	errCheckGiteaReleaseSupport := argCheckInArr(CliNameGiteaReleaseExistsDo, p.Settings.GiteaReleaseExistDo, giteaReleaseExistDoSupport)
 	if errCheckGiteaReleaseSupport != nil {
 		return errCheckGiteaReleaseSupport


### PR DESCRIPTION
feat #38

- Update docker/bake-action from v5 to v6 in both latest and tag workflows
- Add a new step to check build files and display bake-meta.json content
- Modify files input to use cwd:// protocol for better compatibility